### PR TITLE
[FEATURE] 위치 기준 마이멜로디 목록 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,12 @@ dependencies {
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.0.4'
+
+    // queryDsl
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/mymelody/mymelodyserver/domain/Location/entity/Location.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Location/entity/Location.java
@@ -16,5 +16,5 @@ public class Location extends BaseTimeEntity {
     private Long id;
 
     private double latitude; //위도
-    private double longtitude; //경도
+    private double longitude; //경도
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/Music/entity/Music.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Music/entity/Music.java
@@ -15,6 +15,8 @@ public class Music extends BaseTimeEntity {
     @Column(name = "music_id")
     private Long id;
 
+    private String isrc;
+
     private String title;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/controller/MyMelodyController.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/controller/MyMelodyController.java
@@ -5,11 +5,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import mymelody.mymelodyserver.domain.MyMelody.dto.response.GetMyMelodiesByLocation;
-import mymelody.mymelodyserver.domain.MyMelody.dto.response.MyMelodyInfo;
 import mymelody.mymelodyserver.domain.MyMelody.service.MyMelodyService;
+import mymelody.mymelodyserver.global.common.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +22,7 @@ public class MyMelodyController {
 
     private final MyMelodyService myMelodyService;
 
-    @Operation(summary = "반경 1km 내의 마이멜로디 목록 조회(페이지네이션)")
+    @Operation(summary = "반경 1km 내의 마이멜로디 목록 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
@@ -33,25 +32,10 @@ public class MyMelodyController {
             @Parameter(name = "page", description = "조회할 페이지 위치, default는 1"),
             @Parameter(name = "size", description = "조회할 목록 사이즈, default는 10")
     })
-    @GetMapping("/location/page")
-    public ResponseEntity<GetMyMelodiesByLocation> getMyMelodiesByLocation(@RequestParam double latitude,
-            @RequestParam double longitude, @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        return ResponseEntity.ok(myMelodyService.getMyMelodiesByLocationWithPagination(latitude,
-                longitude, page, size));
-    }
-
-    @Operation(summary = "반경 1km 내의 마이멜로디 목록 조회")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공")
-    })
-    @Parameters({
-            @Parameter(name = "latitude", description = "사용자의 현재 위치 위도"),
-            @Parameter(name = "longitude", description = "사용자의 현재 위치 경도")
-    })
     @GetMapping("/location")
-    public ResponseEntity<List<MyMelodyInfo>> getMyMelodiesByLocation(@RequestParam double latitude,
-            @RequestParam double longitude) {
-        return ResponseEntity.ok(myMelodyService.getMyMelodiesByLocation(latitude, longitude));
+    public ResponseEntity<GetMyMelodiesByLocation> getMyMelodiesByLocation(@RequestParam double latitude,
+            @RequestParam double longitude, PageRequest pageRequest) {
+        return ResponseEntity.ok(myMelodyService.getMyMelodiesByLocationWithPagination(latitude,
+                longitude, pageRequest));
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/controller/MyMelodyController.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/controller/MyMelodyController.java
@@ -1,0 +1,57 @@
+package mymelody.mymelodyserver.domain.MyMelody.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import mymelody.mymelodyserver.domain.MyMelody.dto.response.GetMyMelodiesByLocation;
+import mymelody.mymelodyserver.domain.MyMelody.dto.response.MyMelodyInfo;
+import mymelody.mymelodyserver.domain.MyMelody.service.MyMelodyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/mymelody")
+@RequiredArgsConstructor
+public class MyMelodyController {
+
+    private final MyMelodyService myMelodyService;
+
+    @Operation(summary = "반경 1km 내의 마이멜로디 목록 조회(페이지네이션)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @Parameters({
+            @Parameter(name = "latitude", description = "사용자의 현재 위치 위도"),
+            @Parameter(name = "longitude", description = "사용자의 현재 위치 경도"),
+            @Parameter(name = "page", description = "조회할 페이지 위치, default는 1"),
+            @Parameter(name = "size", description = "조회할 목록 사이즈, default는 10")
+    })
+    @GetMapping("/location/page")
+    public ResponseEntity<GetMyMelodiesByLocation> getMyMelodiesByLocation(@RequestParam double latitude,
+            @RequestParam double longitude, @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(myMelodyService.getMyMelodiesByLocationWithPagination(latitude,
+                longitude, page, size));
+    }
+
+    @Operation(summary = "반경 1km 내의 마이멜로디 목록 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @Parameters({
+            @Parameter(name = "latitude", description = "사용자의 현재 위치 위도"),
+            @Parameter(name = "longitude", description = "사용자의 현재 위치 경도")
+    })
+    @GetMapping("/location")
+    public ResponseEntity<List<MyMelodyInfo>> getMyMelodiesByLocation(@RequestParam double latitude,
+            @RequestParam double longitude) {
+        return ResponseEntity.ok(myMelodyService.getMyMelodiesByLocation(latitude, longitude));
+    }
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/GetMyMelodiesByLocation.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/GetMyMelodiesByLocation.java
@@ -1,0 +1,22 @@
+package mymelody.mymelodyserver.domain.MyMelody.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
+import org.springframework.data.domain.Page;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMyMelodiesByLocation {
+
+    private final int totalPages;
+    private final long totalElements;
+    private final List<MyMelodyInfo> myMelodyInfos;
+
+    public static GetMyMelodiesByLocation of(Page<MyMelody> myMelodies) {
+        return new GetMyMelodiesByLocation(myMelodies.getTotalPages(),
+                myMelodies.getTotalElements(), MyMelodyInfo.of(myMelodies.getContent()));
+    }
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/MyMelodyInfo.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/MyMelodyInfo.java
@@ -1,0 +1,30 @@
+package mymelody.mymelodyserver.domain.MyMelody.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MyMelodyInfo {
+
+    private final Long myMelodyId;
+    private final double latitude;
+    private final double longitude;
+    private final String comment;
+
+    private final Long memberId;
+    private final String nickname;
+
+    private final String isrc;
+
+    public static List<MyMelodyInfo> of(List<MyMelody> myMelodies) {
+        return myMelodies.stream()
+                .map(myMelody -> new MyMelodyInfo(myMelody.getId(), myMelody.getLatitude(),
+                        myMelody.getLongitude(), myMelody.getComment(), myMelody.getMember().getId(),
+                        myMelody.getMember().getNickname(), myMelody.getMusic().getIsrc()))
+                .toList();
+    }
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
@@ -18,7 +18,7 @@ public class MyMelody extends BaseTimeEntity {
     private Long id;
 
     private double latitude; //위도
-    private double longtitude; //경도
+    private double longitude; //경도
 
     private String comment;
 

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/repository/MyMelodyCustomRepository.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/repository/MyMelodyCustomRepository.java
@@ -1,0 +1,10 @@
+package mymelody.mymelodyserver.domain.MyMelody.repository;
+
+import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MyMelodyCustomRepository {
+
+    Page<MyMelody> findAllByRange1km(double latitude, double longitude, Pageable pageable);
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/repository/MyMelodyCustomRepositoryImpl.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/repository/MyMelodyCustomRepositoryImpl.java
@@ -1,0 +1,47 @@
+package mymelody.mymelodyserver.domain.MyMelody.repository;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
+import mymelody.mymelodyserver.domain.MyMelody.entity.QMyMelody;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class MyMelodyCustomRepositoryImpl implements MyMelodyCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QMyMelody myMelody = QMyMelody.myMelody;
+
+    @Override
+    public Page<MyMelody> findAllByRange1km(double latitude, double longitude, Pageable pageable) {
+        List<MyMelody> myMelodies = jpaQueryFactory.selectFrom(myMelody)
+                .where(
+                        Expressions.stringTemplate("ST_Distance_Sphere({0}, {1})",
+                                Expressions.stringTemplate("POINT({0}, {1})",
+                                        longitude, latitude),
+                                Expressions.stringTemplate("POINT({0}, {1})",
+                                        myMelody.longitude, myMelody.latitude)
+                        ).loe(String.valueOf(1000))
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = jpaQueryFactory.select(myMelody.count())
+                .from(myMelody)
+                .where(
+                        Expressions.stringTemplate("ST_Distance_Sphere({0}, {1})",
+                                Expressions.stringTemplate("POINT({0}, {1})",
+                                        longitude, latitude),
+                                Expressions.stringTemplate("POINT({0}, {1})",
+                                        myMelody.longitude, myMelody.latitude)
+                        ).loe(String.valueOf(1000))
+                ).fetchOne();
+
+        return new PageImpl<>(myMelodies, pageable, count);
+    }
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/repository/MyMelodyRepository.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/repository/MyMelodyRepository.java
@@ -1,0 +1,23 @@
+package mymelody.mymelodyserver.domain.MyMelody.repository;
+
+import java.util.List;
+import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MyMelodyRepository extends JpaRepository<MyMelody, Long>{
+
+    @Query(value = "SELECT * FROM my_melody m "
+            + "WHERE ST_Distance_Sphere(Point(:longitude,:latitude),POINT(m.longitude, m.latitude)) <= 1000",
+            nativeQuery = true)
+    Page<MyMelody> findAllByRange1km(double latitude, double longitude, Pageable pageable);
+
+    @Query(value = "SELECT * FROM my_melody m "
+            + "WHERE ST_Distance_Sphere(Point(:longitude,:latitude),POINT(m.longitude, m.latitude)) <= 1000",
+            nativeQuery = true)
+    List<MyMelody> findAllByRange1km(double latitude, double longitude);
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/repository/MyMelodyRepository.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/repository/MyMelodyRepository.java
@@ -1,23 +1,10 @@
 package mymelody.mymelodyserver.domain.MyMelody.repository;
 
-import java.util.List;
 import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MyMelodyRepository extends JpaRepository<MyMelody, Long>{
+public interface MyMelodyRepository extends JpaRepository<MyMelody, Long>, MyMelodyCustomRepository {
 
-    @Query(value = "SELECT * FROM my_melody m "
-            + "WHERE ST_Distance_Sphere(Point(:longitude,:latitude),POINT(m.longitude, m.latitude)) <= 1000",
-            nativeQuery = true)
-    Page<MyMelody> findAllByRange1km(double latitude, double longitude, Pageable pageable);
-
-    @Query(value = "SELECT * FROM my_melody m "
-            + "WHERE ST_Distance_Sphere(Point(:longitude,:latitude),POINT(m.longitude, m.latitude)) <= 1000",
-            nativeQuery = true)
-    List<MyMelody> findAllByRange1km(double latitude, double longitude);
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/service/MyMelodyService.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/service/MyMelodyService.java
@@ -1,0 +1,35 @@
+package mymelody.mymelodyserver.domain.MyMelody.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import mymelody.mymelodyserver.domain.MyMelody.dto.response.GetMyMelodiesByLocation;
+import mymelody.mymelodyserver.domain.MyMelody.dto.response.MyMelodyInfo;
+import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
+import mymelody.mymelodyserver.domain.MyMelody.repository.MyMelodyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyMelodyService {
+
+    private final MyMelodyRepository myMelodyRepository;
+
+    public GetMyMelodiesByLocation getMyMelodiesByLocationWithPagination(double latitude, double longitude,
+            int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<MyMelody> myMelodies = myMelodyRepository.findAllByRange1km(latitude, longitude, pageable);
+
+        return GetMyMelodiesByLocation.of(myMelodies);
+    }
+
+    public List<MyMelodyInfo> getMyMelodiesByLocation(double latitude, double longitude) {
+        List<MyMelody> myMelodies = myMelodyRepository.findAllByRange1km(latitude, longitude);
+
+        return MyMelodyInfo.of(myMelodies);
+    }
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/service/MyMelodyService.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/service/MyMelodyService.java
@@ -1,13 +1,11 @@
 package mymelody.mymelodyserver.domain.MyMelody.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import mymelody.mymelodyserver.domain.MyMelody.dto.response.GetMyMelodiesByLocation;
-import mymelody.mymelodyserver.domain.MyMelody.dto.response.MyMelodyInfo;
 import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
 import mymelody.mymelodyserver.domain.MyMelody.repository.MyMelodyRepository;
+import mymelody.mymelodyserver.global.common.PageRequest;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,16 +18,10 @@ public class MyMelodyService {
     private final MyMelodyRepository myMelodyRepository;
 
     public GetMyMelodiesByLocation getMyMelodiesByLocationWithPagination(double latitude, double longitude,
-            int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+            PageRequest pageRequest) {
+        Pageable pageable = pageRequest.of();
         Page<MyMelody> myMelodies = myMelodyRepository.findAllByRange1km(latitude, longitude, pageable);
 
         return GetMyMelodiesByLocation.of(myMelodies);
-    }
-
-    public List<MyMelodyInfo> getMyMelodiesByLocation(double latitude, double longitude) {
-        List<MyMelody> myMelodies = myMelodyRepository.findAllByRange1km(latitude, longitude);
-
-        return MyMelodyInfo.of(myMelodies);
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/global/common/PageRequest.java
+++ b/src/main/java/mymelody/mymelodyserver/global/common/PageRequest.java
@@ -1,0 +1,29 @@
+package mymelody.mymelodyserver.global.common;
+
+import org.springframework.data.domain.Sort.Direction;
+
+public class PageRequest {
+
+    private int page = 1;
+    private int size = 10;
+    private Direction direction = Direction.DESC;
+
+    public void setPage(int page) {
+        this.page = page <= 0 ? 1 : page;
+    }
+
+    public void setSize(int size) {
+        int DEFAULT_SIZE = 10;
+        int MAX_SIZE = 50;
+        this.size = size > MAX_SIZE ? DEFAULT_SIZE : size;
+    }
+
+    public void setDirection(Direction direction) {
+        this.direction = direction;
+    }
+
+    public org.springframework.data.domain.PageRequest of() {
+        return org.springframework.data.domain.PageRequest.of(page - 1, size, direction,
+                "create_date");
+    }
+}

--- a/src/main/java/mymelody/mymelodyserver/global/config/QueryDslConfig.java
+++ b/src/main/java/mymelody/mymelodyserver/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package mymelody.mymelodyserver.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
- 프론트에서 넘겨준 위치 기준 반경 1km 내의 마이멜로디 목록 조회 구현하였습니다.
  - response dto는 일단 확실히 필요한 값들만 넣어두었습니다.
  - music 엔티티에 프론트에서 요청한 isrc 필드 추가하였습니다.
- ~~원래는 페이지네이션으로 구현하려 했는데, repository 로직 실행 시 원인을 알 수 없는 오류가 발생하고 있어 일단 정상 동작하는 리스트 조회도 추가해두었습니다. 일단 발표까지는 리스트 조회로 하고, 이후에 트러블슈팅 더 시도해보겠습니다...ㅠㅠㅠ~~
  - ~~페이지네이션으로 리포지토리에서 조회 시, 결과로 나오는 page에 대해 getTotalPages, getTotalElements는 정상적인 값이 나오는데 getContent에는 빈 값이 들어오는 현상이 발생하고 있습니다...~~
  - queryDsl로 구현하여 해결하였습니다!
- 지금 보니 # 잘못 걸어두고 있었네요 다음부터 주의하겠습니다...ㅎㅎㅎ