### PR TITLE
feat: 좋아요 기능 구현

### DIFF
--- a/src/main/java/mymelody/mymelodyserver/domain/Comment/controller/CommentController.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Comment/controller/CommentController.java
@@ -11,10 +11,12 @@ import lombok.RequiredArgsConstructor;
 import mymelody.mymelodyserver.domain.Comment.dto.request.CreateComment;
 import mymelody.mymelodyserver.domain.Comment.dto.response.GetCommentsByMyMelody;
 import mymelody.mymelodyserver.domain.Comment.service.CommentService;
+import mymelody.mymelodyserver.global.auth.security.CustomUserDetails;
 import mymelody.mymelodyserver.global.common.PageRequest;
 import mymelody.mymelodyserver.global.entity.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,9 +42,9 @@ public class CommentController {
             )
     })
     @PostMapping
-    public ResponseEntity<Void> createComment(@RequestBody CreateComment createComment) {
-        // TODO spring security 적용 후 authenticationPrincipal로 사용자 정보 받아오는 코드 추가
-        commentService.createComment(createComment, 1L);
+    public ResponseEntity<Void> createComment(@RequestBody CreateComment createComment,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        commentService.createComment(createComment, customUserDetails.getMemberId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/mymelody/mymelodyserver/domain/Comment/service/CommentService.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Comment/service/CommentService.java
@@ -34,6 +34,7 @@ public class CommentService {
                 () -> new CustomException(ErrorCode.MYMELODY_NOT_FOUND));
 
         commentRepository.save(createComment.toEntity(member, myMelody));
+        myMelody.increaseTotalComments();
     }
 
     public GetCommentsByMyMelody getCommentsByMyMelody(Long myMelodyId, PageRequest pageRequest) {

--- a/src/main/java/mymelody/mymelodyserver/domain/Likes/controller/LikesController.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Likes/controller/LikesController.java
@@ -1,0 +1,61 @@
+package mymelody.mymelodyserver.domain.Likes.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import mymelody.mymelodyserver.domain.Likes.service.LikesService;
+import mymelody.mymelodyserver.global.auth.security.CustomUserDetails;
+import mymelody.mymelodyserver.global.entity.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/likes")
+@RequiredArgsConstructor
+public class LikesController {
+
+    private final LikesService likesService;
+
+    @Operation(summary = "likes 생성")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "404", description = """
+                    1. 존재하지 않는 사용자
+                    2. 존재하지 않는 마이멜로디""",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/{myMelodyId}")
+    public ResponseEntity<Void> createLikes(@PathVariable Long myMelodyId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        likesService.createLikes(myMelodyId, customUserDetails.getMemberId());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "likes 삭제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = """
+                    1. 존재하지 않는 사용자
+                    2. 존재하지 않는 마이멜로디""",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @DeleteMapping("/{myMelodyId}")
+    public ResponseEntity<Void> deleteLikes(@PathVariable Long myMelodyId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        likesService.deleteLikes(myMelodyId, customUserDetails.getMemberId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/Likes/entity/Likes.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Likes/entity/Likes.java
@@ -1,9 +1,12 @@
-package mymelody.mymelodyserver.domain.Member.entity;
+package mymelody.mymelodyserver.domain.Likes.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mymelody.mymelodyserver.domain.Member.entity.Member;
+import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
 import mymelody.mymelodyserver.global.entity.BaseTimeEntity;
 
 @Entity
@@ -19,6 +22,13 @@ public class Likes extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "my_melody_id")
+    private MyMelody myMelody;
+
+    @Builder
+    public Likes(Member member, MyMelody myMelody) {
+        this.member = member;
+        this.myMelody = myMelody;
+    }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/Likes/repository/LikesRepository.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Likes/repository/LikesRepository.java
@@ -1,0 +1,14 @@
+package mymelody.mymelodyserver.domain.Likes.repository;
+
+import java.util.Optional;
+import mymelody.mymelodyserver.domain.Likes.entity.Likes;
+import mymelody.mymelodyserver.domain.Member.entity.Member;
+import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+
+    Optional<Likes> findByMyMelodyAndMember(MyMelody myMelody, Member member);
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/Likes/service/LikesService.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Likes/service/LikesService.java
@@ -1,0 +1,50 @@
+package mymelody.mymelodyserver.domain.Likes.service;
+
+import lombok.RequiredArgsConstructor;
+import mymelody.mymelodyserver.domain.Likes.entity.Likes;
+import mymelody.mymelodyserver.domain.Likes.repository.LikesRepository;
+import mymelody.mymelodyserver.domain.Member.entity.Member;
+import mymelody.mymelodyserver.domain.Member.repository.MemberRepository;
+import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
+import mymelody.mymelodyserver.domain.MyMelody.repository.MyMelodyRepository;
+import mymelody.mymelodyserver.global.entity.ErrorCode;
+import mymelody.mymelodyserver.global.exception.CustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikesService {
+
+    private final LikesRepository likesRepository;
+    private final MemberRepository memberRepository;
+    private final MyMelodyRepository myMelodyRepository;
+
+    @Transactional
+    public void createLikes(Long myMelodyId, Long memberId) {
+        MyMelody myMelody = myMelodyRepository.findById(myMelodyId).orElseThrow(
+                () -> new CustomException(ErrorCode.MYMELODY_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        likesRepository.save(Likes.builder()
+                .myMelody(myMelody)
+                .member(member)
+                .build());
+        myMelody.increaseTotalLikes();
+    }
+
+    @Transactional
+    public void deleteLikes(Long myMelodyId, Long memberId) {
+        MyMelody myMelody = myMelodyRepository.findById(myMelodyId).orElseThrow(
+                () -> new CustomException(ErrorCode.MYMELODY_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Likes likes = likesRepository.findByMyMelodyAndMember(myMelody, member).orElseThrow(
+                () -> new CustomException(ErrorCode.LIKES_NOT_FOUND));
+
+        likesRepository.delete(likes);
+        myMelody.decreaseTotalLikes();
+    }
+}

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/MyMelodyInfo.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/MyMelodyInfo.java
@@ -14,6 +14,8 @@ public class MyMelodyInfo {
     private final double latitude;
     private final double longitude;
     private final String comment;
+    private final int totalLikes;
+    private final int totalComments;
 
     private final Long memberId;
     private final String nickname;
@@ -23,7 +25,8 @@ public class MyMelodyInfo {
     public static List<MyMelodyInfo> of(List<MyMelody> myMelodies) {
         return myMelodies.stream()
                 .map(myMelody -> new MyMelodyInfo(myMelody.getId(), myMelody.getLatitude(),
-                        myMelody.getLongitude(), myMelody.getComment(), myMelody.getMember().getId(),
+                        myMelody.getLongitude(), myMelody.getComment(), myMelody.getTotalLikes(),
+                        myMelody.getTotalComments(), myMelody.getMember().getId(),
                         myMelody.getMember().getNickname(), myMelody.getMusic().getIsrc()))
                 .toList();
     }

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/MyMelodyInfo.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/MyMelodyInfo.java
@@ -13,7 +13,7 @@ public class MyMelodyInfo {
     private final Long myMelodyId;
     private final double latitude;
     private final double longitude;
-    private final String comment;
+    private final String content;
     private final int totalLikes;
     private final int totalComments;
 
@@ -25,7 +25,7 @@ public class MyMelodyInfo {
     public static List<MyMelodyInfo> of(List<MyMelody> myMelodies) {
         return myMelodies.stream()
                 .map(myMelody -> new MyMelodyInfo(myMelody.getId(), myMelody.getLatitude(),
-                        myMelody.getLongitude(), myMelody.getComment(), myMelody.getTotalLikes(),
+                        myMelody.getLongitude(), myMelody.getContent(), myMelody.getTotalLikes(),
                         myMelody.getTotalComments(), myMelody.getMember().getId(),
                         myMelody.getMember().getNickname(), myMelody.getMusic().getIsrc()))
                 .toList();

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
@@ -21,7 +21,7 @@ public class MyMelody extends BaseTimeEntity {
     private double latitude; //위도
     private double longitude; //경도
 
-    private String comment;
+    private String content;
 
     @ColumnDefault("0")
     private int totalLikes;

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
@@ -26,6 +26,9 @@ public class MyMelody extends BaseTimeEntity {
     @ColumnDefault("0")
     private int totalLikes;
 
+    @ColumnDefault("0")
+    private int totalComments;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -40,5 +43,9 @@ public class MyMelody extends BaseTimeEntity {
 
     public void decreaseTotalLikes() {
         this.totalLikes--;
+    }
+
+    public void increaseTotalComments() {
+        this.totalComments++;
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import mymelody.mymelodyserver.domain.Member.entity.Member;
 import mymelody.mymelodyserver.domain.Music.entity.Music;
 import mymelody.mymelodyserver.global.entity.BaseTimeEntity;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -22,7 +23,8 @@ public class MyMelody extends BaseTimeEntity {
 
     private String comment;
 
-    private int totalLikes = 0;
+    @ColumnDefault("0")
+    private int totalLikes;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/entity/MyMelody.java
@@ -22,6 +22,8 @@ public class MyMelody extends BaseTimeEntity {
 
     private String comment;
 
+    private int totalLikes = 0;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -29,4 +31,12 @@ public class MyMelody extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "music_id")
     private Music music;
+
+    public void increaseTotalLikes() {
+        this.totalLikes++;
+    }
+
+    public void decreaseTotalLikes() {
+        this.totalLikes--;
+    }
 }

--- a/src/main/java/mymelody/mymelodyserver/global/entity/ErrorCode.java
+++ b/src/main/java/mymelody/mymelodyserver/global/entity/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode {
 
     // 404 NOT FOUND
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
-    MYMELODY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마이멜로디를 찾을 수 없습니다.");
+    MYMELODY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마이멜로디를 찾을 수 없습니다."),
+    LIKES_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 마이멜로디에 대한 좋아요를 찾을 수 없습니다.");
 
     // 409 CONFLICT
 


### PR DESCRIPTION
- Likes 엔티티 구체화
  - myMelody 필드 추가
 - 좋아요 생성 및 삭제 구현
 - CommentController에서 memberId 필요한 api에 CustomUserDetails로 받아오도록 수정
 - MyMelody 엔티티 필드 추가 및 수정
   - 좋아요 수, 댓글 수를 보여주면 좋을 것 같아 totalLikes, totalComments 필드를 추가해보았습니다
   - totalComments 필드를 추가하다보니 기존 MyMelody 엔티티의 comment 필드와 필드명이 겹치는 부분이 있어 혼동이 없도록 comment 필드명을 content로 수정해보았습니다