### PR TITLE
feat: 내 좋아요/댓글 여부 확인 필드 추가

### DIFF
--- a/src/main/java/mymelody/mymelodyserver/domain/Comment/controller/CommentController.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Comment/controller/CommentController.java
@@ -59,7 +59,8 @@ public class CommentController {
     })
     @GetMapping("/mymelody/{myMelodyId}")
     public ResponseEntity<GetCommentsByMyMelody> getCommentsByMyMelody(@PathVariable Long myMelodyId,
-            PageRequest pageRequest) {
-        return ResponseEntity.ok(commentService.getCommentsByMyMelody(myMelodyId, pageRequest));
+            PageRequest pageRequest, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok(commentService.getCommentsByMyMelody(myMelodyId, pageRequest,
+                customUserDetails == null ? 0 : customUserDetails.getMemberId()));
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/Comment/dto/response/CommentInfo.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Comment/dto/response/CommentInfo.java
@@ -11,8 +11,9 @@ import mymelody.mymelodyserver.domain.Comment.entity.Comment;
 public class CommentInfo {
 
     private final Long commentId;
-    private final Long memberId;
+    private final String nickname;
     private final String content;
+    private final Boolean isWriter;
 
     public static List<CommentInfo> of(List<Comment> comments) {
         return comments.stream()

--- a/src/main/java/mymelody/mymelodyserver/domain/Comment/dto/response/CommentInfo.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Comment/dto/response/CommentInfo.java
@@ -15,10 +15,10 @@ public class CommentInfo {
     private final String content;
     private final Boolean isWriter;
 
-    public static List<CommentInfo> of(List<Comment> comments) {
+    public static List<CommentInfo> of(List<Comment> comments, Long memberId) {
         return comments.stream()
-                .map(comment -> new CommentInfo(comment.getId(), comment.getMember().getId(),
-                        comment.getContent()))
+                .map(comment -> new CommentInfo(comment.getId(), comment.getMember().getNickname(),
+                        comment.getContent(), comment.getMember().getId().equals(memberId)))
                 .toList();
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/Comment/dto/response/GetCommentsByMyMelody.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Comment/dto/response/GetCommentsByMyMelody.java
@@ -15,8 +15,8 @@ public class GetCommentsByMyMelody {
     private final long totalElements;
     private final List<CommentInfo> commentInfos;
 
-    public static GetCommentsByMyMelody of(Page<Comment> comments) {
+    public static GetCommentsByMyMelody of(Page<Comment> comments, Long memberId) {
         return new GetCommentsByMyMelody(comments.getTotalPages(), comments.getTotalElements(),
-                CommentInfo.of(comments.getContent()));
+                CommentInfo.of(comments.getContent(), memberId));
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/Comment/service/CommentService.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Comment/service/CommentService.java
@@ -37,13 +37,18 @@ public class CommentService {
         myMelody.increaseTotalComments();
     }
 
-    public GetCommentsByMyMelody getCommentsByMyMelody(Long myMelodyId, PageRequest pageRequest) {
+    public GetCommentsByMyMelody getCommentsByMyMelody(Long myMelodyId, PageRequest pageRequest,
+            Long memberId) {
         MyMelody myMelody = myMelodyRepository.findById(myMelodyId).orElseThrow(
                 () -> new CustomException(ErrorCode.MYMELODY_NOT_FOUND));
 
         Pageable pageable = pageRequest.of();
         Page<Comment> comments = commentRepository.findAllByMyMelody(myMelody, pageable);
 
-        return GetCommentsByMyMelody.of(comments);
+        if (memberId != 0 && !memberRepository.existsById(memberId)) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        return GetCommentsByMyMelody.of(comments, memberId);
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/Likes/repository/LikesRepository.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/Likes/repository/LikesRepository.java
@@ -11,4 +11,5 @@ import org.springframework.stereotype.Repository;
 public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     Optional<Likes> findByMyMelodyAndMember(MyMelody myMelody, Member member);
+    Boolean existsByMyMelodyAndMember(MyMelody myMelody, Member member);
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/controller/MyMelodyController.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/controller/MyMelodyController.java
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import mymelody.mymelodyserver.domain.MyMelody.dto.response.GetMyMelodiesByLocation;
 import mymelody.mymelodyserver.domain.MyMelody.service.MyMelodyService;
+import mymelody.mymelodyserver.global.auth.security.CustomUserDetails;
 import mymelody.mymelodyserver.global.common.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,8 +36,9 @@ public class MyMelodyController {
     })
     @GetMapping("/location")
     public ResponseEntity<GetMyMelodiesByLocation> getMyMelodiesByLocation(@RequestParam double latitude,
-            @RequestParam double longitude, PageRequest pageRequest) {
+            @RequestParam double longitude, PageRequest pageRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         return ResponseEntity.ok(myMelodyService.getMyMelodiesByLocationWithPagination(latitude,
-                longitude, pageRequest));
+                longitude, pageRequest, customUserDetails == null ? 0 : customUserDetails.getMemberId()));
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/GetMyMelodiesByLocation.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/GetMyMelodiesByLocation.java
@@ -4,8 +4,6 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
-import org.springframework.data.domain.Page;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,8 +13,8 @@ public class GetMyMelodiesByLocation {
     private final long totalElements;
     private final List<MyMelodyInfo> myMelodyInfos;
 
-    public static GetMyMelodiesByLocation of(Page<MyMelody> myMelodies) {
-        return new GetMyMelodiesByLocation(myMelodies.getTotalPages(),
-                myMelodies.getTotalElements(), MyMelodyInfo.of(myMelodies.getContent()));
+    public static GetMyMelodiesByLocation of(int totalPages, long totalElements,
+            List<MyMelodyInfo> myMelodyInfos) {
+        return new GetMyMelodiesByLocation(totalPages, totalElements, myMelodyInfos);
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/MyMelodyInfo.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/dto/response/MyMelodyInfo.java
@@ -1,6 +1,5 @@
 package mymelody.mymelodyserver.domain.MyMelody.dto.response;
 
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -17,17 +16,14 @@ public class MyMelodyInfo {
     private final int totalLikes;
     private final int totalComments;
 
-    private final Long memberId;
     private final String nickname;
+    private final Boolean isLiked;
 
     private final String isrc;
 
-    public static List<MyMelodyInfo> of(List<MyMelody> myMelodies) {
-        return myMelodies.stream()
-                .map(myMelody -> new MyMelodyInfo(myMelody.getId(), myMelody.getLatitude(),
-                        myMelody.getLongitude(), myMelody.getContent(), myMelody.getTotalLikes(),
-                        myMelody.getTotalComments(), myMelody.getMember().getId(),
-                        myMelody.getMember().getNickname(), myMelody.getMusic().getIsrc()))
-                .toList();
+    public static MyMelodyInfo of(MyMelody myMelody, Boolean isLiked) {
+        return new MyMelodyInfo(myMelody.getId(), myMelody.getLatitude(), myMelody.getLongitude(),
+                myMelody.getContent(), myMelody.getTotalLikes(), myMelody.getTotalComments(),
+                myMelody.getMember().getNickname(), isLiked, myMelody.getMusic().getIsrc());
     }
 }

--- a/src/main/java/mymelody/mymelodyserver/domain/MyMelody/service/MyMelodyService.java
+++ b/src/main/java/mymelody/mymelodyserver/domain/MyMelody/service/MyMelodyService.java
@@ -1,10 +1,18 @@
 package mymelody.mymelodyserver.domain.MyMelody.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import mymelody.mymelodyserver.domain.Likes.repository.LikesRepository;
+import mymelody.mymelodyserver.domain.Member.entity.Member;
+import mymelody.mymelodyserver.domain.Member.repository.MemberRepository;
 import mymelody.mymelodyserver.domain.MyMelody.dto.response.GetMyMelodiesByLocation;
+import mymelody.mymelodyserver.domain.MyMelody.dto.response.MyMelodyInfo;
 import mymelody.mymelodyserver.domain.MyMelody.entity.MyMelody;
 import mymelody.mymelodyserver.domain.MyMelody.repository.MyMelodyRepository;
 import mymelody.mymelodyserver.global.common.PageRequest;
+import mymelody.mymelodyserver.global.entity.ErrorCode;
+import mymelody.mymelodyserver.global.exception.CustomException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,12 +24,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class MyMelodyService {
 
     private final MyMelodyRepository myMelodyRepository;
+    private final MemberRepository memberRepository;
+    private final LikesRepository likesRepository;
 
     public GetMyMelodiesByLocation getMyMelodiesByLocationWithPagination(double latitude, double longitude,
-            PageRequest pageRequest) {
+            PageRequest pageRequest, Long memberId) {
         Pageable pageable = pageRequest.of();
         Page<MyMelody> myMelodies = myMelodyRepository.findAllByRange1km(latitude, longitude, pageable);
 
-        return GetMyMelodiesByLocation.of(myMelodies);
+        List<MyMelodyInfo> myMelodyInfos = new ArrayList<>();
+        if (memberId != 0) {
+            Member member = memberRepository.findById(memberId).orElseThrow(
+                    () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+            myMelodies.getContent().forEach(myMelody -> myMelodyInfos.add(MyMelodyInfo.of(myMelody,
+                        likesRepository.existsByMyMelodyAndMember(myMelody, member))));
+        } else {
+            myMelodies.getContent().forEach(myMelody -> myMelodyInfos.add(MyMelodyInfo.of(myMelody, false)));
+        }
+
+        return GetMyMelodiesByLocation.of(myMelodies.getTotalPages(), myMelodies.getTotalElements(),
+                myMelodyInfos);
     }
 }


### PR DESCRIPTION
- 마이멜로디 조회 시 사용자가 좋아요를 누른 마이멜로디인지 확인하는 필드를 MyMelodyInfo에 추가
- 댓글 조회 시 사용자가 작성한 댓글인지 확인하는 필드를 Comment에 추가
- 두 필드 모두 로그인한 사용자 정보를 받아와야하는데, 저희 서비스가 로그인하지 않고도 마이멜로디 자체는 확인가능한지 정해지지 않은 것 같아 CustomUserDetails가 null인 경우를 고려한 로직을 작성했습니다
  - CustomUserDetails가 null이면 memberId를 0으로 넘겨주게 됩니다